### PR TITLE
Update KeyName to AWS-specific parameter type

### DIFF
--- a/src/main/static-content/cloudformation/kinesis-data-vis-sample-app.template
+++ b/src/main/static-content/cloudformation/kinesis-data-vis-sample-app.template
@@ -14,12 +14,7 @@
 
     "KeyName" : {
       "Description" : "(Optional) Name of an existing EC2 KeyPair to enable SSH access to the instance. If this is not provided you will not be able to SSH on to the EC2 instance.",
-      "Type" : "String",
-      "Default" : "",
-      "MinLength" : "0",
-      "MaxLength" : "255",
-      "AllowedPattern" : "[\\x20-\\x7E]*",
-      "ConstraintDescription" : "can contain only ASCII characters."
+      "Type" : "AWS::EC2::KeyPair::KeyName"
     },
 
     "SSHLocation" : {


### PR DESCRIPTION
Use `AWS::EC2::KeyPair::KeyName`, an AWS-specific
parameter type, rather than `String`.